### PR TITLE
Relax CORS constraints

### DIFF
--- a/conf.d/enable-cors.conf
+++ b/conf.d/enable-cors.conf
@@ -1,11 +1,7 @@
 if ($request_method = 'OPTIONS') {
-    # multiple Access-Control-Allow-Origin headers in response if Origin header is found in Request
     add_header 'Access-Control-Allow-Origin' '*';
-    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-    #
-    # Custom headers and headers various browsers *should* be OK with but aren't
-    #
-    add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,x-radixdlt-correlation-id,x-radixdlt-method,x-radixdlt-target-gw-api ';
+    add_header 'Access-Control-Allow-Methods' '*';
+    add_header 'Access-Control-Allow-Headers' '*';
     #
     # Tell client that this pre-flight info is valid for 20 days
     #
@@ -15,6 +11,6 @@ if ($request_method = 'OPTIONS') {
     return 204;
 }
 add_header 'Access-Control-Allow-Origin' '*' always ;
-add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always ;
-add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,x-radixdlt-correlation-id,x-radixdlt-method' always;
+add_header 'Access-Control-Allow-Methods' '*' always ;
+add_header 'Access-Control-Allow-Headers' '*' always;
 add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;


### PR DESCRIPTION
Community users suffer from incorrect CORS setup when they run `babylonnode` - mainy: various headers configured by our TS SDKs. As all the data exposed by Core API or GW API is publicly available and there's no sensitive information over there's no much point in protecting those APIs behind CORS.