### PR TITLE
[DO-2477] Fix nginx logs destination

### DIFF
--- a/conf.d/nginx.conf.envsubst
+++ b/conf.d/nginx.conf.envsubst
@@ -99,16 +99,16 @@ http {
 
     ${INCLUDE_DEFAULT_RATE_LIMITS}
 
-    error_log stderr notice;
+    error_log /dev/stderr notice;
     server {
         listen 443 ssl;
         server_name localhost;
 
         include conf.d/enable-compression.conf;
 
-        access_log stderr json_analytics if=${DOLLAR}loggable;
+        access_log /dev/stderr json_analytics if=${DOLLAR}loggable;
         access_log $NGINX_LOGS_DIR/access_bad.log json_analytics if=${DOLLAR}loggable;
-        access_log stdout json_analytics;
+        access_log /dev/stdout json_analytics;
 
         #include conf.d/cloudflare-allow.conf;
         #deny all;

--- a/generate_artifact.sh
+++ b/generate_artifact.sh
@@ -16,8 +16,9 @@ sed '1,/# nginx configuration/!d' docker-entrypoint.sh  | sed 's/\/etc\/nginx/${
 mv ${PWD}/nginx.conf ${PWD}/$nginx_file_name
 #Remove nginx user
 sed -i "s|user nginx;|include \/etc\/nginx\/modules-enabled\/*.conf;|g" ${PWD}/$nginx_file_name
-#Change /dev/stdout
+#Change /dev/stdout and /dev/stderr
 sed -i "s|\/dev\/stdout|\/var\/log\/nginx\/access.log|g" ${PWD}/$nginx_file_name
+sed -i "s|\/dev\/stderr|\/var\/log\/nginx\/error.log|g" ${PWD}/$nginx_file_name
 zip -r babylon-nginx-fullnode-conf.zip conf.d/ certs/ nginx-fullnode.conf
 #Cleanup
 rm nginx-fullnode.conf


### PR DESCRIPTION
Write access_logs to `/dev/stdout` and error_logs to `/dev/stderr` instead of `/etc/nginx/stdout` and `/etc/nginx/stderr`.
